### PR TITLE
Map bigdecimal to decimal/numeric

### DIFF
--- a/fastetl/custom_functions/utils/config/types_mapping.yml
+++ b/fastetl/custom_functions/utils/config/types_mapping.yml
@@ -80,10 +80,20 @@ teiid:
   bigdecimal:
     postgres:
       dtype:
-        FLOAT8
+        DECIMAL
+      max_length:
+        32767 : '38, 8'
+      length_columns:
+        - Precision
+        - Scale
     mssql:
       dtype:
-        FLOAT
+        NUMERIC
+      max_length:
+        32767 : '38, 8'
+      length_columns:
+        - Precision
+        - Scale
   timestamp:
     postgres:
       dtype:


### PR DESCRIPTION
- Change mapping for bigdecimal (origin/teiid) to decimal/numeric (destination/psql/mssql) instead of float type.