### PR TITLE
improve create table and teiid conn_type

### DIFF
--- a/fastetl/custom_functions/utils/db_connection.py
+++ b/fastetl/custom_functions/utils/db_connection.py
@@ -7,7 +7,6 @@ from typing import Tuple
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine, URL
 import pyodbc
-import psycopg2
 
 from airflow.hooks.base import BaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
@@ -212,7 +211,7 @@ def get_conn_type(conn_id: str) -> str:
     conn_values = BaseHook.get_connection(conn_id)
     conn_type = (
         "teiid"
-        if "teiid" in conn_values.description
+        if conn_values.description and "teiid" in conn_values.description
         else conn_values.conn_type
     )
 

--- a/fastetl/custom_functions/utils/table_comments.py
+++ b/fastetl/custom_functions/utils/table_comments.py
@@ -5,6 +5,7 @@ target. Works between Postgres, MySql, MsSql.
 
 import pandas as pd
 from sqlalchemy import inspect
+from sqlalchemy.exc import OperationalError
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
@@ -433,7 +434,10 @@ class TableComments:
         if self.conn_type == "mssql":
             table_comments = self._get_mssql_table_comments()
         elif self.conn_type == "postgres":
-            table_comments = self._get_pg_table_comments()
+            try:
+                table_comments = self._get_pg_table_comments()
+            except OperationalError:
+                table_comments = self._get_teiid_table_comments()
         elif self.conn_type == "teiid":
             table_comments = self._get_teiid_table_comments()
         else:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 
 """Perform the package apache-airflow-providers-fastetl setup."""
 setup(


### PR DESCRIPTION
* na criação de tabela: altera descobrimento se tabela existe com query para `create table if exists...`
* altera descobrimento se conexão é teiid de query na tabela SYS.Tables para leitura do parâmetro `description` da conexão do airflow
* quando `teiid` não preenchido na conexão do airflow, tenta consertar com try, except nas funções postgres