### PR TITLE
add quotation for create table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.1-python3.10
+FROM apache/airflow:2.6.3-python3.10
 
 USER root
 

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -66,7 +66,7 @@ def _create_table_ddl(destination: DestinationConnection, df: pd.DataFrame):
     sql_columns = []
     for _, row in df.iterrows():
         sql_columns.append(
-            f"{row['Name']} {row['DataType']}{row['converted_length']}"
+            f"\"{row['Name']}\" {row['DataType']}{row['converted_length']}"
         )
 
     sql_columns_str = ', '.join(sql_columns)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 
 """Perform the package apache-airflow-providers-fastetl setup."""
 setup(

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       AIRFLOW__CORE__DEFAULT_TIMEZONE: 'America/Sao_Paulo'
       AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+      AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA: 'true'
     volumes:
       - ../tests:/opt/airflow/tests
       - ../tests/test_dag.py:/opt/airflow/dags/test_dag.py


### PR DESCRIPTION
- Add quotas in sql statement for creating table.
 (This was necessary to prevent tables with system reserved columns.)
 - Update airflow build image to 2.6.3
 - Include env var AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA (needed for OdbcHook to prepare tests)