### PR TITLE
Add param debug_mode

### DIFF
--- a/fastetl/hooks/db_to_db_hook.py
+++ b/fastetl/hooks/db_to_db_hook.py
@@ -24,12 +24,14 @@ class DbToDbHook(BaseHook):
         self.source = source
         self.destination = destination
 
+
     def full_copy(
         self,
         columns_to_ignore: list = None,
         destination_truncate: str = True,
         chunksize: int = 1000,
         copy_table_comments: bool = False,
+        debug_mode: bool = False
     ):
         copy_db_to_db(
             source=self.source,
@@ -38,6 +40,7 @@ class DbToDbHook(BaseHook):
             destination_truncate=destination_truncate,
             chunksize=chunksize,
             copy_table_comments=copy_table_comments,
+            debug_mode=debug_mode
         )
 
     def incremental_copy(
@@ -49,6 +52,7 @@ class DbToDbHook(BaseHook):
         sync_exclusions: bool = False,
         chunksize: int = 1000,
         copy_table_comments: bool = False,
+        debug_mode: bool = False
     ):
         sync_db_2_db(
             source_conn_id=self.source["conn_id"],
@@ -67,4 +71,5 @@ class DbToDbHook(BaseHook):
             sync_exclusions=sync_exclusions,
             chunksize=chunksize,
             copy_table_comments=copy_table_comments,
+            debug_mode=debug_mode
         )

--- a/fastetl/hooks/db_to_db_hook.py
+++ b/fastetl/hooks/db_to_db_hook.py
@@ -40,7 +40,6 @@ class DbToDbHook(BaseHook):
             destination_truncate=destination_truncate,
             chunksize=chunksize,
             copy_table_comments=copy_table_comments,
-            debug_mode=debug_mode
         )
 
     def incremental_copy(
@@ -71,5 +70,4 @@ class DbToDbHook(BaseHook):
             sync_exclusions=sync_exclusions,
             chunksize=chunksize,
             copy_table_comments=copy_table_comments,
-            debug_mode=debug_mode
         )

--- a/fastetl/operators/db_to_db_operator.py
+++ b/fastetl/operators/db_to_db_operator.py
@@ -77,6 +77,7 @@ Args:
     copy_table_comments (bool, optional): Whether to copy table comments
         from the source database to the destination database.
         Defaults to False.
+    debug_mode (bool, optional): Whether to enable debug mode. Defaults to False.
 
 Raises:
     TypeError: If `source` or `destination` is not a dictionary.
@@ -112,6 +113,7 @@ class DbToDbOperator(BaseOperator):
         key_column: str = None,
         since_datetime: datetime = None,
         sync_exclusions: bool = False,
+        debug_mode: bool = False,
         *args,
         **kwargs,
     ) -> None:
@@ -126,6 +128,7 @@ class DbToDbOperator(BaseOperator):
         self.key_column = key_column
         self.since_datetime = since_datetime
         self.sync_exclusions = sync_exclusions
+        self.debug_mode = debug_mode
 
         # rename if schema_name is present
         if source.get("schema_name", None):
@@ -166,6 +169,7 @@ class DbToDbOperator(BaseOperator):
                 sync_exclusions=self.sync_exclusions,
                 chunksize=self.chunksize,
                 copy_table_comments=self.copy_table_comments,
+                debug_mode=self.debug_mode,
             )
         else:
             hook.full_copy(
@@ -173,4 +177,5 @@ class DbToDbOperator(BaseOperator):
                 destination_truncate=self.destination_truncate,
                 chunksize=self.chunksize,
                 copy_table_comments=self.copy_table_comments,
+                debug_mode=self.debug_mode,
             )


### PR DESCRIPTION
Add the debug_mode parameter in DbtoDBOperator for incremental and full copies.

When set to **True**, this parameter outputs the builded SQL for debugging purposes.

The default value is **False**.