### PR TITLE
Create table based on query source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Here are only the breaking and most significant changes. For a full
 account of changes, please see the
 [commit history](https://github.com/gestaogovbr/FastETL/commits/main).
 
+
+## 0.0.43
+* Update DbtoDbOperator to create destination table from a query source
+
 ## 0.0.40
 * Update openmetadata-ingestion lib. It was affecting pydantic version.
 

--- a/fastetl/custom_functions/fast_etl.py
+++ b/fastetl/custom_functions/fast_etl.py
@@ -267,9 +267,9 @@ def copy_db_to_db(
     destination = DestinationConnection(destination)
 
     # create table if not exists in destination db
-    if not source.query:
-        create_table_if_not_exists(source, destination)
+    create_table_if_not_exists(source, destination)
 
+    if not source.query:
         if copy_table_comments:
             _copy_table_comments(source, destination)
 

--- a/fastetl/custom_functions/utils/config/types_mapping.yml
+++ b/fastetl/custom_functions/utils/config/types_mapping.yml
@@ -147,12 +147,12 @@ postgres:
     postgres:
       dtype: TEXT
     mssql:
-      dtype: TEXT
+      dtype: NVARCHAR(MAX)
   1043:
     postgres:
       dtype: VARCHAR
     mssql:
-      dtype: NVARCHAR
+      dtype: NVARCHAR(MAX)
   1082:
     postgres:
       dtype: DATE
@@ -167,7 +167,7 @@ postgres:
     postgres:
       dtype: TIMESTAMP
     mssql:
-      dtype: DATETIME
+      dtype: DATETIME2
   1184:
     postgres:
       dtype: TIMESTAMP WITH TZ
@@ -204,83 +204,45 @@ postgres:
     mssql:
       dtype: UNIQUEIDENTIFIER
 mssql:
-  34:
+  int:
     postgres:
-      dtype: BYTEA
+      dtype:
+        INTEGER
     mssql:
-      dtype: IMAGE
-  35:
+      dtype:
+        INT
+  str:
     postgres:
-      dtype: TEXT
+      dtype:
+        TEXT
     mssql:
-      dtype: TEXT
-  36:
+      dtype:
+        NVARCHAR(MAX)
+  float:
     postgres:
-      dtype: UUID
+      dtype:
+        DOUBLE PRECISION
     mssql:
-      dtype: UNIQUEIDENTIFIER
-  40:
+      dtype:
+        FLOAT
+  bool:
     postgres:
-      dtype: DATE
+      dtype:
+        BOOLEAN
     mssql:
-      dtype: DATE
-  41:
+      dtype:
+        BIT
+  datetime:
     postgres:
-      dtype: TIME
+      dtype:
+        TIMESTAMP
     mssql:
-      dtype: TIME
-  42:
+      dtype:
+        DATETIME2
+  date:
     postgres:
-      dtype: TIMESTAMP WITH TZ
+      dtype:
+        DATE
     mssql:
-      dtype: DATETIME2
-  52:
-    postgres:
-      dtype: SMALLINT
-    mssql:
-      dtype: SMALLINT
-  56:
-    postgres:
-      dtype: INTEGER
-    mssql:
-      dtype: INT
-  59:
-    postgres:
-      dtype: DOUBLE PRECISION
-    mssql:
-      dtype: FLOAT
-  60:
-    postgres:
-      dtype: NUMERIC
-    mssql:
-      dtype: MONEY
-  61:
-    postgres:
-      dtype: TIMESTAMP
-    mssql:
-      dtype: DATETIME
-  106:
-    postgres:
-      dtype: NUMERIC
-    mssql:
-      dtype: DECIMAL
-  108:
-    postgres:
-      dtype: NUMERIC
-    mssql:
-      dtype: NUMERIC
-  127:
-    postgres:
-      dtype: BIGINT
-    mssql:
-      dtype: BIGINT
-  167:
-    postgres:
-      dtype: VARCHAR
-    mssql:
-      dtype: NVARCHAR
-  175:
-    postgres:
-      dtype: CHAR
-    mssql:
-      dtype: NCHAR
+      dtype:
+        DATE

--- a/fastetl/custom_functions/utils/config/types_mapping.yml
+++ b/fastetl/custom_functions/utils/config/types_mapping.yml
@@ -122,3 +122,165 @@ teiid:
     mssql:
       dtype:
         VARBINARY
+postgres:
+  16:
+    postgres:
+      dtype: BOOLEAN
+    mssql:
+      dtype: BIT
+  20:
+    postgres:
+      dtype: BIGINT
+    mssql:
+      dtype: BIGINT
+  21:
+    postgres:
+      dtype: SMALLINT
+    mssql:
+      dtype: SMALLINT
+  23:
+    postgres:
+      dtype: INTEGER
+    mssql:
+      dtype: INT
+  25:
+    postgres:
+      dtype: TEXT
+    mssql:
+      dtype: TEXT
+  1043:
+    postgres:
+      dtype: VARCHAR
+    mssql:
+      dtype: NVARCHAR
+  1082:
+    postgres:
+      dtype: DATE
+    mssql:
+      dtype: DATE
+  1083:
+    postgres:
+      dtype: TIME
+    mssql:
+      dtype: TIME
+  1114:
+    postgres:
+      dtype: TIMESTAMP
+    mssql:
+      dtype: DATETIME
+  1184:
+    postgres:
+      dtype: TIMESTAMP WITH TZ
+    mssql:
+      dtype: DATETIME2
+  1700:
+    postgres:
+      dtype: NUMERIC
+    mssql:
+      dtype: DECIMAL
+  701:
+    postgres:
+      dtype: DOUBLE PRECISION
+    mssql:
+      dtype: FLOAT
+  700:
+    postgres:
+      dtype: REAL
+    mssql:
+      dtype: FLOAT
+  17:
+    postgres:
+      dtype: BYTEA
+    mssql:
+      dtype: IMAGE
+  114:
+    postgres:
+      dtype: JSON
+    mssql:
+      dtype: TEXT
+  2950:
+    postgres:
+      dtype: UUID
+    mssql:
+      dtype: UNIQUEIDENTIFIER
+mssql:
+  34:
+    postgres:
+      dtype: BYTEA
+    mssql:
+      dtype: IMAGE
+  35:
+    postgres:
+      dtype: TEXT
+    mssql:
+      dtype: TEXT
+  36:
+    postgres:
+      dtype: UUID
+    mssql:
+      dtype: UNIQUEIDENTIFIER
+  40:
+    postgres:
+      dtype: DATE
+    mssql:
+      dtype: DATE
+  41:
+    postgres:
+      dtype: TIME
+    mssql:
+      dtype: TIME
+  42:
+    postgres:
+      dtype: TIMESTAMP WITH TZ
+    mssql:
+      dtype: DATETIME2
+  52:
+    postgres:
+      dtype: SMALLINT
+    mssql:
+      dtype: SMALLINT
+  56:
+    postgres:
+      dtype: INTEGER
+    mssql:
+      dtype: INT
+  59:
+    postgres:
+      dtype: DOUBLE PRECISION
+    mssql:
+      dtype: FLOAT
+  60:
+    postgres:
+      dtype: NUMERIC
+    mssql:
+      dtype: MONEY
+  61:
+    postgres:
+      dtype: TIMESTAMP
+    mssql:
+      dtype: DATETIME
+  106:
+    postgres:
+      dtype: NUMERIC
+    mssql:
+      dtype: DECIMAL
+  108:
+    postgres:
+      dtype: NUMERIC
+    mssql:
+      dtype: NUMERIC
+  127:
+    postgres:
+      dtype: BIGINT
+    mssql:
+      dtype: BIGINT
+  167:
+    postgres:
+      dtype: VARCHAR
+    mssql:
+      dtype: NVARCHAR
+  175:
+    postgres:
+      dtype: CHAR
+    mssql:
+      dtype: NCHAR

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -321,6 +321,26 @@ def create_table_from_others(
             "Please create the table manually to execute data copying."
         )
         raise e
+def query_first_row(source: SourceConnection):
+    """Query to get the first row of a table or query.
+    Args:
+        source (SourceConnection): A `SourceConnection` object containing
+            the connection details for the source database.
+    Returns:
+        str: SQL query to get the first row of a table or query.
+    """
+    # Remove semicolon if exists
+    query = source.query[:-1] if source.query.endswith(";") else source.query
+
+    # Get the first row of the query
+    if source.conn_type in ("postgres", "mysql", "teiid"):
+        metadata_query = f"SELECT * FROM ({query}) AS subquery LIMIT 1"
+    elif source.conn_type == "mssql":
+        metadata_query = f"SELECT TOP 1 subquery.* FROM ({query}) AS subquery"
+    else:
+        raise ValueError
+
+    return metadata_query
 
 def create_table_from_query(
     source: SourceConnection, destination: DestinationConnection

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -26,6 +26,7 @@ from sqlalchemy.exc import OperationalError
 from airflow.hooks.base import BaseHook
 
 from fastetl.custom_functions.utils.db_connection import (
+    DbConnection,
     SourceConnection,
     DestinationConnection,
     get_hook_and_engine_by_provider,
@@ -69,7 +70,7 @@ def _create_table_ddl(destination: DestinationConnection, df: pd.DataFrame):
             f"\"{row['Name']}\" {row['DataType']}{row['converted_length']}"
         )
 
-    sql_columns_str = ', '.join(sql_columns)
+    sql_columns_str = ", ".join(sql_columns)
 
     if destination.conn_type == "mssql":
         query = f"""
@@ -87,9 +88,7 @@ def _create_table_ddl(destination: DestinationConnection, df: pd.DataFrame):
             );
         """
     else:
-        raise ValueError(
-            f"Connection type {destination.conn_type} no implemented yet."
-        )
+        raise ValueError(f"Connection type {destination.conn_type} no implemented yet.")
 
     return query
 
@@ -133,9 +132,7 @@ def _convert_datatypes(
             row["converted_length"] = f"({','.join(values)})"
 
             if "max_length" in types_node:
-                max_length, mapped_length = next(
-                    iter(types_node["max_length"].items())
-                )
+                max_length, mapped_length = next(iter(types_node["max_length"].items()))
                 # uses only the first length_column of a list to compare
                 # with column max_length
                 if row[length_columns[0]] >= max_length:
@@ -240,7 +237,6 @@ def create_table_from_teiid(
         _execute_query(destination.conn_id, table_ddl)
     else:
         logging.warning("Source table metadata from teiid is empty")
-
 
 
 def create_table_from_others(
@@ -377,7 +373,9 @@ def create_table_from_query(
                 index=False,
             )
 
-            logging.info(f"Destination table {destination.schema}.{destination.table} created successfully.")
+            logging.info(
+                f"Destination table {destination.schema}.{destination.table} created successfully."
+            )
 
     except AssertionError as e:  # pylint: disable=invalid-name
         logging.error(

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -88,7 +88,7 @@ def _create_table_ddl(destination: DestinationConnection, df: pd.DataFrame):
             );
         """
     else:
-        raise ValueError(f"Connection type {destination.conn_type} no implemented yet.")
+        raise ValueError(f"Connection type {destination.conn_type} not implemented yet.")
 
     return query
 

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -487,10 +487,13 @@ def create_table_if_not_exists(
         to implement `create_table_from_others(source, destination)`
         scenarios (source table from databases mssql and postgres)
     """
-    if not source.query and source.table:
+    if not source.query:
         if source.conn_type == "teiid":
             create_table_from_teiid(source, destination)
         else:
             create_table_from_others(source, destination)
     else:
-        create_table_from_cursor(source, destination)
+        if source.conn_type == "teiid":
+            create_table_from_query_using_pandas(source, destination)
+        else:
+            create_table_from_query_using_cursor(source, destination)

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -32,3 +32,16 @@ with DAG(
                     "table": 'destination_table',
                 },
             )
+        for dest_conf in db_confs:
+            DbToDbOperator(
+                task_id=f'test_from_{source_conf[0]}_query_to_{dest_conf[0]}',
+                source={
+                    "conn_id": f'{source_conf[0]}-source-conn',
+                    "query": f"SELECT * FROM {source_conf[1]}.source_table"
+                },
+                destination={
+                    "conn_id": f'{dest_conf[0]}-destination-conn',
+                    "schema": dest_conf[1],
+                    "table": 'destination_table',
+                },
+            )

--- a/tests/test_db_to_db_operator.py
+++ b/tests/test_db_to_db_operator.py
@@ -74,7 +74,7 @@ def generate_transactions(
                 DESCRIPTIONS[randint(0, 3)],
                 randint(1, 1000000),
                 round(uniform(0, 1000), 2),
-                DATETIMES[randint(0, 3)].date(),
+                DATETIMES[randint(0, 3)],
                 ACTIVES[randint(0, 1)],
                 DATETIMES[randint(0, 3)],
             )
@@ -246,4 +246,134 @@ def test_full_table_replication_various_db_types(
         f"select * from {dest_table_name} order by id asc;"
     )
 
+    assert_frame_equal(source_data, dest_data)
+
+@pytest.mark.parametrize(
+    "source_conn_id, source_hook_cls, source_provider, dest_conn_id, "
+    "dest_hook_cls, destination_provider, has_dest_table",
+    [
+        (
+            "postgres-source-conn",
+            PostgresHook,
+            "postgres",
+            "postgres-destination-conn",
+            PostgresHook,
+            "postgres",
+            True,
+        ),
+        (
+            "mssql-source-conn",
+            OdbcHook,
+            "mssql",
+            "mssql-destination-conn",
+            OdbcHook,
+            "mssql",
+            True,
+        ),
+        (
+            "postgres-source-conn",
+            PostgresHook,
+            "postgres",
+            "mssql-destination-conn",
+            OdbcHook,
+            "mssql",
+            True,
+        ),
+        (
+            "mssql-source-conn",
+            OdbcHook,
+            "mssql",
+            "postgres-destination-conn",
+            PostgresHook,
+            "postgres",
+            True,
+        ),
+        (
+            "postgres-source-conn",
+            PostgresHook,
+            "postgres",
+            "postgres-destination-conn",
+            PostgresHook,
+            "postgres",
+            False,
+        ),
+        (
+            "mssql-source-conn",
+            OdbcHook,
+            "mssql",
+            "mssql-destination-conn",
+            OdbcHook,
+            "mssql",
+            False,
+        ),
+        (
+            "postgres-source-conn",
+            PostgresHook,
+            "postgres",
+            "mssql-destination-conn",
+            OdbcHook,
+            "mssql",
+            False,
+        ),
+        (
+            "mssql-source-conn",
+            OdbcHook,
+            "mssql",
+            "postgres-destination-conn",
+            PostgresHook,
+            "postgres",
+            False,
+        ),
+    ],
+)
+def test_query_replication_various_db_types(
+    source_conn_id: str,
+    source_hook_cls: DbApiHook,
+    source_provider: str,
+    dest_conn_id: str,
+    dest_hook_cls: DbApiHook,
+    destination_provider: str,
+    has_dest_table: bool,
+):
+    """Test query replication using various database types.
+
+    Args:
+        source_conn_id (str): source database connection id.
+        source_hook_cls (DbApiHook): source database hook class.
+        source_provider (str): source database provider.
+        dest_conn_id (str): destination database connection id.
+        dest_hook_cls (DbApiHook): destination database hook class.
+        destination_provider (str): destination database provider.
+        has_dest_table (bool): whether or not to create the table at
+            the destination database before testing replication.
+    """
+    source_table_name = "source_table"
+    dest_table_name = "destination_table"
+    source_hook = source_hook_cls(source_conn_id)
+    dest_hook = dest_hook_cls(dest_conn_id)
+
+    # Setup
+    _try_drop_table(source_table_name, source_hook)
+    _insert_initial_source_table_n_data(source_table_name, source_hook, source_provider)
+
+    _try_drop_table(dest_table_name, dest_hook)
+    if has_dest_table:
+        _create_initial_table(dest_table_name, dest_hook, destination_provider)
+
+    # Run
+    task_id = f"test_from_{source_provider}_query_to_{destination_provider}".lower()
+    subprocess.run(
+        ["airflow", "tasks", "test", "test_dag", task_id, "2021-01-01"], check=True
+    )
+
+    # Assert
+    source_data = source_hook.get_pandas_df(
+        f"select * from {source_table_name} order by id asc;"
+    )
+    dest_data = dest_hook.get_pandas_df(
+        f"select * from {dest_table_name} order by id asc;"
+    )
+
+    # Compare only the values (with df.to_sql impossible to ensure the same dtypes)
+    #np.array_equal(source_data.values,dest_data.values)
     assert_frame_equal(source_data, dest_data)


### PR DESCRIPTION
fix #187
- Create table based on query source.

  If source query is teiid create destination table using pandas to_sql method.
  If source query is postgresql or mssql create destination table using _pyodbc/psycopg2_ cursor.

- Create new test for query replication
- Add new values in columns mapping yaml file
