### PR TITLE
Install package as editable in a mounted volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ USER airflow
 RUN pip install --no-cache-dir \
     apache-airflow[microsoft.mssql,odbc,samba] \
     apache-airflow-providers-common-sql \
-    pytest==6.2.5 \
-    /opt/airflow/fastetl \
-    && rm -rf /opt/airflow/fastetl
+    pytest==6.2.5
+
+RUN pip install -e /opt/airflow/fastetl
 
 RUN airflow db init
 

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,10 @@ down:
 
 .PHONY: tests
 tests:
-	docker exec airflow pytest -vvv --color=yes
+	docker compose -f tests/docker-compose.yml exec airflow pytest -vvv --color=yes
+
+# example: make test TEST_FILTER=test_put_participante_missing_mandatory_fields
+# command `$ make test TEST_FILTER="test_put_participante_missing_mandatory_fields"`
+.PHONY: test
+test:
+	docker compose -f tests/docker-compose.yml exec airflow pytest -k $(TEST_FILTER) -vvv --color=yes

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA: 'true'
     volumes:
-      - ../tests:/opt/airflow/tests
+      - ../fastetl:/opt/airflow/fastetl/fastetl
+      - ../tests:/opt/airflow/fastetl/tests
       - ../tests/test_dag.py:/opt/airflow/dags/test_dag.py
     container_name: airflow
     ports:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: always
 
   postgres-source:
-    image: postgres:11.4-alpine
+    image: postgres:16-alpine
     restart: always
     container_name: postgres-source
     ports:
@@ -34,7 +34,7 @@ services:
       - POSTGRES_DB=db
 
   postgres-destination:
-    image: postgres:11.4-alpine
+    image: postgres:16-alpine
     restart: always
     container_name: postgres-destination
     ports:

--- a/tests/test_db_to_db_operator.py
+++ b/tests/test_db_to_db_operator.py
@@ -46,7 +46,7 @@ def _try_drop_table(table_name: str, hook: DbApiHook) -> None:
 
 def _create_initial_table(table_name: str, hook: DbApiHook, db_provider: str) -> None:
     filename = f"create_{table_name}_{db_provider.lower()}.sql"
-    path = "/opt/airflow/tests/sql/init/"
+    path = "/opt/airflow/fastetl/tests/sql/init/"
     with open(os.path.join(path, filename), "r", encoding="utf-8") as file:
         sql_statement = file.read()
     hook.run(sql_statement.format(table_name=table_name))


### PR DESCRIPTION
Change development and test environment so that:
- the source code and test code are mounted as a volume and
- the FastETL package is installed as editable

That way, a developer can edit the code and run the tests iteratively. The same environment still works for CI/CD as well.

Fix #206