### PR TITLE
Remove any surrounding whitespace from query before fetching first row

### DIFF
--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -325,9 +325,11 @@ def create_table_from_others(
 
 def query_first_row(source: SourceConnection):
     """Query to get the first row of a table or query.
+
     Args:
         source (SourceConnection): A `SourceConnection` object containing
             the connection details for the source database.
+
     Returns:
         str: SQL query to get the first row of a table or query.
     """

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -354,6 +354,7 @@ def query_first_row(source: SourceConnection):
 
     return metadata_query
 
+
 def create_table_from_query_using_pandas(
     source: SourceConnection, destination: DestinationConnection
 ):

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -321,6 +321,8 @@ def create_table_from_others(
             "Please create the table manually to execute data copying."
         )
         raise e
+
+
 def query_first_row(source: SourceConnection):
     """Query to get the first row of a table or query.
     Args:

--- a/fastetl/custom_functions/utils/create_table.py
+++ b/fastetl/custom_functions/utils/create_table.py
@@ -333,8 +333,12 @@ def query_first_row(source: SourceConnection):
     Returns:
         str: SQL query to get the first row of a table or query.
     """
-    # Remove semicolon if exists
-    query = source.query[:-1] if source.query.endswith(";") else source.query
+    # Remove whitespace around query, if any
+    query = source.query.strip()
+
+    # Remove semicolon at the end, if present
+    if query.endswith(";"):
+        query = query[:-1]
 
     # Get the first row of the query
     if source.conn_type in ("postgres", "mysql"):


### PR DESCRIPTION
Fix #217

This patch strips any whitespace surrounding the query before using it as a subquery to fetch the first row.