### PR TITLE
Create a flag in DbtoDbOperator wether or not to create the table at the destination

### DIFF
--- a/fastetl/custom_functions/fast_etl.py
+++ b/fastetl/custom_functions/fast_etl.py
@@ -201,6 +201,7 @@ def copy_db_to_db(
     destination: Dict[str, str],
     columns_to_ignore: list = None,
     destination_truncate: bool = True,
+    destination_create: bool = True,
     chunksize: int = 1000,
     copy_table_comments: bool = False,
     load_type: str = "full",
@@ -254,6 +255,9 @@ def copy_db_to_db(
 
         columns_to_ignore (list, optional): A list of column names to
             ignore during the copy operation. Defaults to None.
+        destination_create (bool, optional): If True, the destination
+            table may be created if it does not already exist. Defaults
+            to True.
         destination_truncate (bool, optional): If True, the destination
             table will be truncated before copying data. Defaults to True.
         chunksize (int, optional): The number of rows to copy at once.
@@ -276,8 +280,9 @@ def copy_db_to_db(
     source = SourceConnection(source)
     destination = DestinationConnection(destination)
 
-    # create table if not exists in destination db
-    create_table_if_not_exists(source, destination)
+    if destination_create:
+        # create table if not exists in destination db
+        create_table_if_not_exists(source, destination)
 
     if not source.query:
         if copy_table_comments:

--- a/fastetl/custom_functions/utils/get_table_cols_name.py
+++ b/fastetl/custom_functions/utils/get_table_cols_name.py
@@ -2,13 +2,13 @@
 Get database table columns names.
 """
 
-from typing import List
+from typing import List, Optional
 
 from fastetl.custom_functions.utils.db_connection import DbConnection
 
 
 def get_table_cols_name(
-    conn_id: str, schema: str, table: str, columns_to_ignore: List = None
+    conn_id: str, schema: str, table: str, columns_to_ignore: Optional[List[str]] = None
 ) -> List[str]:
     """
     Obtem a lista de colunas de uma tabela.

--- a/fastetl/hooks/db_to_db_hook.py
+++ b/fastetl/hooks/db_to_db_hook.py
@@ -28,7 +28,8 @@ class DbToDbHook(BaseHook):
     def full_copy(
         self,
         columns_to_ignore: list = None,
-        destination_truncate: str = True,
+        destination_truncate: bool = True,
+        destination_create: bool = True,
         chunksize: int = 1000,
         copy_table_comments: bool = False,
         debug_mode: bool = False
@@ -38,6 +39,7 @@ class DbToDbHook(BaseHook):
             destination=self.destination,
             columns_to_ignore=columns_to_ignore,
             destination_truncate=destination_truncate,
+            destination_create=destination_create,
             chunksize=chunksize,
             copy_table_comments=copy_table_comments,
             debug_mode=debug_mode,

--- a/fastetl/operators/db_to_db_operator.py
+++ b/fastetl/operators/db_to_db_operator.py
@@ -105,6 +105,7 @@ class DbToDbOperator(BaseOperator):
         destination: Dict[str, str],
         columns_to_ignore: list = None,
         destination_truncate: bool = True,
+        destination_create: bool = True,
         chunksize: int = 1000,
         copy_table_comments: bool = False,
         is_incremental: bool = False,
@@ -121,6 +122,7 @@ class DbToDbOperator(BaseOperator):
         super().__init__(*args, **kwargs)
         self.columns_to_ignore = columns_to_ignore
         self.destination_truncate = destination_truncate
+        self.destination_create = destination_create
         self.chunksize = chunksize
         self.copy_table_comments = copy_table_comments
         self.is_incremental = is_incremental
@@ -179,6 +181,7 @@ class DbToDbOperator(BaseOperator):
             hook.full_copy(
                 columns_to_ignore=self.columns_to_ignore,
                 destination_truncate=self.destination_truncate,
+                destination_create=self.destination_create,
                 chunksize=self.chunksize,
                 copy_table_comments=self.copy_table_comments,
                 debug_mode=self.debug_mode,


### PR DESCRIPTION
A flag not to attempt to create the table at the destination.

A workaround so that tables from PostGIS do not crash while copying, until proper support is implemented.

Related to #219 